### PR TITLE
Fix locale-sensitive routing

### DIFF
--- a/pages/404.vue
+++ b/pages/404.vue
@@ -9,7 +9,7 @@
   -->
   <div class="grid min-h-full grid-cols-1 grid-rows-[1fr_auto_1fr] bg-white lg:grid-cols-[max(50%,36rem)_1fr]">
     <header class="mx-auto w-full max-w-7xl px-6 pt-6 sm:pt-10 lg:col-span-2 lg:col-start-1 lg:row-start-1 lg:px-8">
-      <NuxtLink to="/">
+      <NuxtLink :to="localePath('/')">
         <span class="sr-only">{{ $t('home.title') }}</span>
         <img class="h-10 w-auto sm:h-12" src="https://tailwindcss.com/plus-assets/img/logos/mark.svg?color=indigo&shade=600" alt="" >
       </NuxtLink>
@@ -20,7 +20,7 @@
         <h1 class="mt-4 text-5xl font-semibold tracking-tight text-pretty text-gray-900 sm:text-6xl">{{ $t('404.title') }}</h1>
         <p class="mt-6 text-lg font-medium text-pretty text-gray-500 sm:text-xl/8">{{ $t('404.description') }}</p>
         <div class="mt-10">
-          <NuxtLink to="/" class="text-sm/7 font-semibold text-indigo-600">
+          <NuxtLink :to="localePath('/')" class="text-sm/7 font-semibold text-indigo-600">
             <span aria-hidden="true">&larr;</span> {{ $t('404.backToHome') }}
           </NuxtLink>
         </div>
@@ -45,6 +45,7 @@
 
 <script setup>
 const { t } = useI18n()
+const localePath = useLocalePath()
 
 // SEO Meta - 修复标题翻译问题
 useHead({

--- a/pages/auth/login.vue
+++ b/pages/auth/login.vue
@@ -103,8 +103,8 @@
               </label>
             </div>
             
-            <NuxtLink 
-              to="/forgot-password" 
+            <NuxtLink
+              :to="localePath('/forgot-password')"
               class="text-sm text-indigo-600 hover:text-indigo-500"
             >
               {{ $t('login.forgotPassword') }}
@@ -155,8 +155,8 @@
         <div class="mt-6 border-t border-gray-200 pt-6 text-center">
           <p class="text-sm text-gray-600">
             {{ $t('login.noAccount') }}
-            <NuxtLink 
-              to="/auth/register" 
+            <NuxtLink
+              :to="localePath('/auth/register')"
               class="text-indigo-600 hover:text-indigo-500 font-medium"
             >
               {{ $t('login.signUp') }}
@@ -173,6 +173,7 @@ import { EyeIcon, EyeSlashIcon, XCircleIcon } from '@heroicons/vue/24/outline'
 
 // i18n
 const { t } = useI18n()
+const localePath = useLocalePath()
 
 // 页面元信息 - 修复标题翻译问题
 useHead({
@@ -254,8 +255,9 @@ const handleLogin = async () => {
     const redirectPath = getRoleRedirectPath(user.role)
     await navigateTo(redirectPath)
 
-  } catch (err: any) {
-    error.value = err.message || t('login.errors.loginFailed')
+  } catch (err: unknown) {
+    const message = err instanceof Error ? err.message : String(err)
+    error.value = message || t('login.errors.loginFailed')
   } finally {
     pending.value = false
   }

--- a/pages/auth/register.vue
+++ b/pages/auth/register.vue
@@ -175,11 +175,11 @@
             </div>
             <label for="agree-terms" class="ml-3 block text-sm/6 text-gray-900">
               {{ $t('register.agreeTerms') }}
-              <NuxtLink to="/terms" class="text-indigo-600 hover:text-indigo-500">
+              <NuxtLink :to="localePath('/terms')" class="text-indigo-600 hover:text-indigo-500">
                 {{ $t('register.termsOfService') }}
               </NuxtLink>
               {{ $t('register.and') }}
-              <NuxtLink to="/privacy" class="text-indigo-600 hover:text-indigo-500">
+              <NuxtLink :to="localePath('/privacy')" class="text-indigo-600 hover:text-indigo-500">
                 {{ $t('register.privacyPolicy') }}
               </NuxtLink>
             </label>
@@ -240,8 +240,8 @@
         <div class="mt-6 border-t border-gray-200 pt-6 text-center">
           <p class="text-sm text-gray-600">
             {{ $t('register.alreadyHaveAccount') }}
-            <NuxtLink 
-              to="/auth/login" 
+            <NuxtLink
+              :to="localePath('/auth/login')"
               class="text-indigo-600 hover:text-indigo-500 font-medium"
             >
               {{ $t('register.signIn') }}
@@ -258,6 +258,7 @@ import { EyeIcon, EyeSlashIcon, XCircleIcon, CheckCircleIcon } from '@heroicons/
 
 // i18n
 const { t } = useI18n()
+const localePath = useLocalePath()
 
 // 页面元信息
 useHead({
@@ -415,8 +416,9 @@ const handleRegister = async () => {
       navigateTo('/auth/login')
     }, 3000)
 
-  } catch (err: any) {
-    error.value = err.message || t('register.errors.registrationFailed')
+  } catch (err: unknown) {
+    const message = err instanceof Error ? err.message : String(err)
+    error.value = message || t('register.errors.registrationFailed')
   } finally {
     pending.value = false
   }

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -25,8 +25,8 @@
             {{ $t('home.subtitle') }}
           </p>
           <div class="mt-10 flex items-center justify-center gap-x-6">
-            <NuxtLink 
-              to="/login" 
+            <NuxtLink
+              :to="localePath('/auth/login')"
               class="rounded-md bg-indigo-600 px-3.5 py-2.5 text-sm font-semibold text-white shadow-sm hover:bg-indigo-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600"
             >
               {{ $t('home.loginNow') }}
@@ -106,8 +106,8 @@
                 </ul>
               </div>
             </div>
-            <NuxtLink 
-              to="/auth/login" 
+            <NuxtLink
+              :to="localePath('/auth/login')"
               class="mt-6 w-full rounded-md bg-indigo-50 px-3 py-2 text-sm font-semibold text-indigo-600 hover:bg-indigo-100 text-center transition-colors"
             >
               {{ $t('home.loginAs', { role: $t(role.name) }) }}
@@ -128,8 +128,8 @@
             {{ $t('home.joinDescription') }}
           </p>
           <div class="mt-10 flex items-center justify-center gap-x-6">
-            <NuxtLink 
-              to="/auth/login" 
+            <NuxtLink
+              :to="localePath('/auth/login')"
               class="rounded-md bg-white px-3.5 py-2.5 text-sm font-semibold text-indigo-600 shadow-sm hover:bg-gray-50 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white"
             >
               {{ $t('home.tryNow') }}
@@ -159,6 +159,7 @@ import {
 import { useI18n } from 'vue-i18n'
 
 const { t } = useI18n()
+const localePath = useLocalePath()
 
 const features = [
   {


### PR DESCRIPTION
## Summary
- ensure locale-aware links in the auth and home pages
- reference locale-aware URLs in error page
- fix lint errors by avoiding `any`

## Testing
- `yarn lint`
- `yarn type-check` *(fails: requires vue-tsc install)*

------
https://chatgpt.com/codex/tasks/task_b_6846d987146c8320a5fd7208abcbb817